### PR TITLE
Integrate concourse builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+FROM r.j3ss.co/img:v0.5.6 AS img
 FROM docker:18.09
 
 RUN apk add --no-cache \
@@ -14,12 +15,18 @@ RUN apk add --no-cache \
   libffi-dev \
   openssl-dev \
   gcc \
-  libc-dev
+  libc-dev \
+  # img dependencies
+  git
 
 ARG DOCKER_COMPOSE_VERSION='1.24.0'
 
 RUN pip --no-cache-dir install "docker-compose==${DOCKER_COMPOSE_VERSION}" "awscli"
 
 COPY ./docker-helpers.sh .
+
+COPY --from=img /usr/bin/img /usr/bin/img
+COPY --from=img /usr/bin/newuidmap /usr/bin/newuidmap
+COPY --from=img /usr/bin/newgidmap /usr/bin/newgidmap
 
 CMD "ash"

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ARG DOCKER_COMPOSE_VERSION='1.24.0'
 RUN pip --no-cache-dir install "docker-compose==${DOCKER_COMPOSE_VERSION}" "awscli"
 
 COPY ./docker-helpers.sh .
-COPY ./build .
+COPY ./build /usr/bin/build
 
 COPY --from=img /usr/bin/img /usr/bin/img
 COPY --from=img /usr/bin/newuidmap /usr/bin/newuidmap

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ARG DOCKER_COMPOSE_VERSION='1.24.0'
 RUN pip --no-cache-dir install "docker-compose==${DOCKER_COMPOSE_VERSION}" "awscli"
 
 COPY ./docker-helpers.sh .
+COPY ./build .
 
 COPY --from=img /usr/bin/img /usr/bin/img
 COPY --from=img /usr/bin/newuidmap /usr/bin/newuidmap

--- a/build
+++ b/build
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+set -e -u
+
+function sanitize_cgroups() {
+  mkdir -p /sys/fs/cgroup
+  mountpoint -q /sys/fs/cgroup || \
+    mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+
+  mount -o remount,rw none /sys/fs/cgroup
+
+  sed -e 1d /proc/cgroups | while read sys hierarchy num enabled; do
+    if [ "$enabled" != "1" ]; then
+      # subsystem disabled; skip
+      continue
+    fi
+
+    grouping="$(cat /proc/self/cgroup | cut -d: -f2 | grep "\\<$sys\\>")" || true
+    if [ -z "$grouping" ]; then
+      # subsystem not mounted anywhere; mount it on its own
+      grouping="$sys"
+    fi
+
+    mountpoint="/sys/fs/cgroup/$grouping"
+
+    mkdir -p "$mountpoint"
+
+    # clear out existing mount to make sure new one is read-write
+    if mountpoint -q "$mountpoint"; then
+      umount "$mountpoint"
+    fi
+
+    mount -n -t cgroup -o "$grouping" cgroup "$mountpoint"
+
+    if [ "$grouping" != "$sys" ]; then
+      if [ -L "/sys/fs/cgroup/$sys" ]; then
+        rm "/sys/fs/cgroup/$sys"
+      fi
+
+      ln -s "$mountpoint" "/sys/fs/cgroup/$sys"
+    fi
+  done
+
+  if ! test -e /sys/fs/cgroup/systemd ; then
+    mkdir /sys/fs/cgroup/systemd
+    mount -t cgroup -o none,name=systemd none /sys/fs/cgroup/systemd
+  fi
+}
+
+sanitize_cgroups
+
+stty columns 80
+
+ran_progress="false"
+
+function progress() {
+  if [ "$ran_progress" = "true" ]; then
+    echo ""
+  fi
+
+  ran_progress="true"
+
+  echo $'\e[1m'"$@"$'\e[0m'
+}
+
+TAG=${TAG:-latest}
+CONTEXT=${CONTEXT:-.}
+DOCKERFILE=${DOCKERFILE:-$CONTEXT/Dockerfile}
+BUILD_ARGS_OPT=$(env | awk '/BUILD_ARG_/ {gsub(/BUILD_ARG_/, "--build-arg "); printf "%s ",$0}')
+
+if [ -d ./cache/state ]; then
+  progress "syncing cache to state"
+  rsync -a ./cache/state/ /scratch/state
+fi
+
+if [ -e ./cache/whiteouts ]; then
+  cat ./cache/whiteouts | while read path; do
+    echo "restoring whiteout: $path"
+    mknod -m0 $path c 0 0
+  done
+fi
+
+progress "building"
+img build -s /scratch/state -t $REPOSITORY:$TAG -f $DOCKERFILE $BUILD_ARGS_OPT $CONTEXT
+
+if [ -d ./cache ]; then
+  progress "syncing state to cache"
+
+  > ./cache/whiteouts
+  find /scratch/state -type c | while read device; do
+    types=$(stat -c '%t,%T' "$device")
+    if [ "$types" = "0,0" ]; then
+      echo "recording whiteout: $device"
+      echo $device >> ./cache/whiteouts
+      rm $device
+    else
+      echo "caching non-whiteout char device ($types): $device"
+    fi
+  done
+
+  rsync -a /scratch/state/ ./cache/state
+fi
+
+progress "saving image"
+img save -s /scratch/state -o image/image.tar $REPOSITORY:$TAG

--- a/build
+++ b/build
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Sourced from https://github.com/concourse/builder-task/blob/86acd415595f2b13c4ee3aa53fab970b1b30e1c9/build
+# Copyright 2018 Pivotal Software, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License")
+
 set -e -u
 
 function sanitize_cgroups() {

--- a/build
+++ b/build
@@ -66,7 +66,11 @@ function progress() {
 TAG=${TAG:-latest}
 CONTEXT=${CONTEXT:-.}
 DOCKERFILE=${DOCKERFILE:-$CONTEXT/Dockerfile}
-BUILD_ARGS_OPT=$(env | awk '/BUILD_ARG_/ {gsub(/BUILD_ARG_/, "--build-arg "); printf "%s ",$0}')
+BUILD_ARGS_OPT=()
+while read -r line; do
+  BUILD_ARGS_OPT+=('--build-arg')
+  BUILD_ARGS_OPT+=("${line}")
+done <<<"$(env | grep -E '^BUILD_ARG_' | sed -n 's/^BUILD_ARG_//p')"
 
 if [ -d ./cache/state ]; then
   progress "syncing cache to state"
@@ -81,7 +85,7 @@ if [ -e ./cache/whiteouts ]; then
 fi
 
 progress "building"
-img build -s /scratch/state -t $REPOSITORY:$TAG -f $DOCKERFILE $BUILD_ARGS_OPT $CONTEXT
+img build -s /scratch/state -t $REPOSITORY:$TAG -f $DOCKERFILE "${BUILD_ARGS_OPT[@]}" $CONTEXT
 
 if [ -d ./cache ]; then
   progress "syncing state to cache"


### PR DESCRIPTION
This allows our runner to function the same way as the [concourse builder task](https://github.com/concourse/builder-task).

While this isn't ideal, it allows us to iteratively improve the build script without needing to wait for upstream to merge, or introducing the overhead of maintaining another image.

This is not ideal, and once active development is done and all our changes are merged upstream, we should change back to concourse/builder-task.