### PR TITLE
Refactor Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,36 @@
-FROM docker/compose:1.24.0
+ARG DOCKER_VERSION='18.09'
+ARG DOCKER_COMPOSE_VERSION='1.24.0'
 
-ARG PASSWORD_STORE_VERSION='1.7.3'
+FROM docker:${DOCKER_VERSION} AS docker-cli
+FROM docker/compose:${DOCKER_COMPOSE_VERSION}
+
+COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
+
+ENV PASSWORD_STORE_VERSION "1.7.3"
+ENV AWSCLI_VERSION "1.16.154"
 
 RUN apk add --no-cache \
-    # our dependencies
-    make \
-    bash \
-    curl \
-    # passwordstore deps
-    git \
-    gnupg \
-    # awscli deps
-    py-pip \
- && git clone https://git.zx2c4.com/password-store -b "${PASSWORD_STORE_VERSION}" \
+  # our dependencies
+  make \
+  bash \
+  curl \
+  # passwordstore deps
+  git \
+  gnupg \
+  # awscli deps
+  python \
+  py-pip \
+ && git clone https://git.zx2c4.com/password-store -b $PASSWORD_STORE_VERSION \
  && cd password-store \
  && wget "http://www.zx2c4.com/keys/AB9942E6D4A4CFC3412620A749FC7012A5DE03AE.asc" \
  && gpg --import AB9942E6D4A4CFC3412620A749FC7012A5DE03AE.asc \
- && git tag --verify "${PASSWORD_STORE_VERSION}" \
+ && git tag --verify $PASSWORD_STORE_VERSION \
  && make install \
  && cd - \
  && rm -rf password-store \
- && pip --no-cache-dir install awscli
+ && pip install awscli==$AWSCLI_VERSION \
+ && apk --purge -v del py-pip
 
 COPY ./docker-helpers.sh .
 
-ENTRYPOINT "ash"
+ENTRYPOINT ["ash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN apk add --no-cache \
     # passwordstore deps
     git \
     gnupg \
+    # awscli deps
+    py-pip \
  && git clone https://git.zx2c4.com/password-store -b "${PASSWORD_STORE_VERSION}" \
  && cd password-store \
  && wget "http://www.zx2c4.com/keys/AB9942E6D4A4CFC3412620A749FC7012A5DE03AE.asc" \
@@ -17,7 +19,8 @@ RUN apk add --no-cache \
  && git tag --verify "${PASSWORD_STORE_VERSION}" \
  && make install \
  && cd - \
- && rm -rf password-store
+ && rm -rf password-store \
+ && pip --no-cache-dir install awscli
 
 COPY ./docker-helpers.sh .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,24 @@
-FROM docker:18.09
+FROM docker/compose:1.24.0
 
-RUN apk add --no-cache \
-  # our dependencies
-  make \
-  bash \
-  curl \
-  # dockerd dependencies
-  util-linux \
-  iptables \
-  # docker-compose dependencies
-  py-pip \
-  python-dev \
-  libffi-dev \
-  openssl-dev \
-  gcc \
-  libc-dev \
-  # passwordstore deps
-  git \
-  gnupg
-
-ARG DOCKER_COMPOSE_VERSION='1.24.0'
 ARG PASSWORD_STORE_VERSION='1.7.3'
 
-WORKDIR /tmp/password-store
-ADD "http://www.zx2c4.com/keys/AB9942E6D4A4CFC3412620A749FC7012A5DE03AE.asc" /tmp
-RUN gpg --import "/tmp/AB9942E6D4A4CFC3412620A749FC7012A5DE03AE.asc" \
-  && git clone https://git.zx2c4.com/password-store -b "${PASSWORD_STORE_VERSION}" . \
-  && git tag --verify "${PASSWORD_STORE_VERSION}" \
-  && make install \
-  && rm -rf "/tmp/AB9942E6D4A4CFC3412620A749FC7012A5DE03AE.asc" "/tmp/password-store"
-
-WORKDIR /
-RUN pip --no-cache-dir install "docker-compose==${DOCKER_COMPOSE_VERSION}" "awscli"
+RUN apk add --no-cache \
+    # our dependencies
+    make \
+    bash \
+    curl \
+    # passwordstore deps
+    git \
+    gnupg \
+ && git clone https://git.zx2c4.com/password-store -b "${PASSWORD_STORE_VERSION}" \
+ && cd password-store \
+ && wget "http://www.zx2c4.com/keys/AB9942E6D4A4CFC3412620A749FC7012A5DE03AE.asc" \
+ && gpg --import AB9942E6D4A4CFC3412620A749FC7012A5DE03AE.asc \
+ && git tag --verify "${PASSWORD_STORE_VERSION}" \
+ && make install \
+ && cd - \
+ && rm -rf password-store
 
 COPY ./docker-helpers.sh .
 
-CMD "ash"
+ENTRYPOINT "ash"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,27 @@
 ARG DOCKER_VERSION='18.09'
 ARG DOCKER_COMPOSE_VERSION='1.24.0'
+ARG ALPINE_VERSION='3.9'
 
+FROM docker/compose:${DOCKER_COMPOSE_VERSION} AS docker-compose
 FROM docker:${DOCKER_VERSION} AS docker-cli
-FROM docker/compose:${DOCKER_COMPOSE_VERSION}
 
-COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
+FROM alpine:${ALPINE_VERSION} AS passwordstore
+ARG PASSWORD_STORE_VERSION='1.7.3'
 
-ENV PASSWORD_STORE_VERSION "1.7.3"
-ENV AWSCLI_VERSION "1.16.154"
+RUN apk add --no-cache \
+  make \
+  git \
+  gnupg \
+  && git clone https://git.zx2c4.com/password-store -b ${PASSWORD_STORE_VERSION} \
+  && cd password-store \
+  && wget "http://www.zx2c4.com/keys/AB9942E6D4A4CFC3412620A749FC7012A5DE03AE.asc" \
+  && gpg --import AB9942E6D4A4CFC3412620A749FC7012A5DE03AE.asc \
+  && git tag --verify ${PASSWORD_STORE_VERSION} \
+  && make install
+
+FROM alpine:${ALPINE_VERSION} AS runtime
+
+ARG AWSCLI_VERSION='1.16.154'
 
 RUN apk add --no-cache \
   # our dependencies
@@ -15,22 +29,22 @@ RUN apk add --no-cache \
   bash \
   curl \
   # passwordstore deps
-  git \
   gnupg \
+  # dockerd dependencies	
+  util-linux \	
+  iptables \
   # awscli deps
-  python \
-  py-pip \
- && git clone https://git.zx2c4.com/password-store -b $PASSWORD_STORE_VERSION \
- && cd password-store \
- && wget "http://www.zx2c4.com/keys/AB9942E6D4A4CFC3412620A749FC7012A5DE03AE.asc" \
- && gpg --import AB9942E6D4A4CFC3412620A749FC7012A5DE03AE.asc \
- && git tag --verify $PASSWORD_STORE_VERSION \
- && make install \
- && cd - \
- && rm -rf password-store \
- && pip install awscli==$AWSCLI_VERSION \
- && apk --purge -v del py-pip
+  python2 \
+  py2-pip \
+  # setup aws-cli
+  && pip --no-cache-dir install awscli==${AWSCLI_VERSION} \
+  && apk --purge -v del py-pip
 
 COPY ./docker-helpers.sh .
+
+COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
+COPY --from=docker-compose /usr/local/bin/docker-compose /usr/local/bin/docker-compose
+COPY --from=passwordstore /usr/lib/password-store/ /usr/lib/password-store/
+COPY --from=passwordstore /usr/bin/pass /usr/bin
 
 ENTRYPOINT ["ash"]


### PR DESCRIPTION
Base the image on the `docker/compose` image and use a single `RUN`
command to minimise how many layers get created.

The resulting image is around a quarter of the size than it was previously and it's much faster to build.