### PR TITLE
Use the builtin set_pipeline in ci/pipeline.yml

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -7,11 +7,6 @@ groups:
   - self-update
 
 resources:
-  - name: tech-ops
-    type: git
-    source:
-      uri: https://github.com/alphagov/tech-ops.git
-
   - name: govwifi-concourse-runner
     type: git
     source:
@@ -37,19 +32,10 @@ jobs:
   - name: self-update
     serial: true
     plan:
-    - get: tech-ops
-      params:
-        submodules: none
     - get: govwifi-concourse-runner
       trigger: true
-    - task: set-pipelines
-      file: tech-ops/ci/tasks/self-updating-pipeline.yaml
-      input_mapping: {repository: govwifi-concourse-runner}
-      params:
-        CONCOURSE_TEAM: govwifi
-        CONCOURSE_PASSWORD: ((readonly_local_user_password))
-        PIPELINE_PATH: ci/pipeline.yml
-        PIPELINE_NAME: runner
+    - set_pipeline: runner
+      file: govwifi-concourse-runner/ci/pipeline.yml
 
   - name: build
     plan:


### PR DESCRIPTION
This avoids using the deprecated tech-ops task, and works better with
the GovWifi Concourse.